### PR TITLE
Fixed script to work with Task ID argument

### DIFF
--- a/monitoring/send_task_data_to_influx.py
+++ b/monitoring/send_task_data_to_influx.py
@@ -117,6 +117,9 @@ def main(args):
             print ("ERROR: Failed to get last Rally task ID ")
             print (output)
             raise exception
+    else:
+        print ("Using task: {}".format(task_id))
+        parse_and_send_to_influx(task_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The script was not working when sending a task id as
argument. this patch fixes that