### PR TITLE
Sort Graphs By Test Type instead of by file name

### DIFF
--- a/monitoring/RallyReports.ipynb
+++ b/monitoring/RallyReports.ipynb
@@ -3,7 +3,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -11,7 +14,7 @@
     "import matplotlib.pyplot as plt\n",
     "import json\n",
     "import os\n",
-    "\n",
+    "import operator\n",
     "\n",
     "# Gets the moving average (mean) values \n",
     "def moving_avg(a, window):\n",
@@ -43,7 +46,31 @@
     "        relative_degradation.append(temp)\n",
     "    return relative_degradation\n",
     "\n",
+    "taskFiles = []\n",
     "for f in os.listdir('./'):\n",
+    "    task_id = ''\n",
+    "    if f.endswith('.json'):\n",
+    "        task_id = f.split('.')[0]\n",
+    "    else:\n",
+    "        continue\n",
+    "    # Import Rally task results, \n",
+    "    # The files are in the same directory as this Jupyter notebook\n",
+    "    json_string = open('./{}.json'.format(task_id)).read()\n",
+    "    try:\n",
+    "        data = json.loads(json_string)\n",
+    "    except:\n",
+    "        continue\n",
+    "    scenario = data[0][\"key\"][\"name\"]\n",
+    "    #print(scenario)\n",
+    "    taskFiles.append((f, scenario))\n",
+    "       \n",
+    "taskFiles.sort(key=operator.itemgetter(1))    \n",
+    "    \n",
+    "sortedTaskFiles = []    \n",
+    "for f in taskFiles:\n",
+    "    sortedTaskFiles.append(f[0]) \n",
+    "    \n",
+    "for f in sortedTaskFiles:\n",
     "    task_id = ''\n",
     "    if f.endswith('.json'):\n",
     "        task_id = f.split('.')[0]\n",
@@ -239,25 +266,44 @@
     "                   \" with the task results\".format(task_id))\n",
     "            continue"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2.0
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
File name is often GUID, and hence the graphs show up in an essentially random order if they're sorted by GUID.  This isn't perfect, but is a big step toward sorting the graphs by test type.