### PR TITLE
Fixed inconsistency with moving AVG calculation

### DIFF
--- a/monitoring/RallyReports-SingleFile.ipynb
+++ b/monitoring/RallyReports-SingleFile.ipynb
@@ -5,7 +5,7 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [],
    "source": [
@@ -47,7 +47,7 @@
     "    return relative_degradation\n",
     "\n",
     "\n",
-    "task_id = '085523b6-a6d7-458a-9249-40856737b5de' # Here goes the task ID\n",
+    "task_id = '84ff85e5-08d2-4e14-a10e-d8f9187ba04a' # Here goes the task ID\n",
     "\n",
     "# Import Rally task results, \n",
     "# The files are in the same directory as this Jupyter notebook\n",
@@ -97,7 +97,7 @@
     "                                     if len(d[\"error\"]) > 0])\n",
     "\n",
     "        # All Durations\n",
-    "        all_dur = success_dur + failure_dur\n",
+    "        all_dur = [d[\"duration\"] for d in all_samples]\n",
     "        # All Timestamps Sorted ASC\n",
     "        all_ts = sorted(success_timestamps + failure_timestamps)\n",
     "\n",
@@ -119,7 +119,7 @@
     "\n",
     "        # Calulate moving AVG (mean) in 10s time window \n",
     "\n",
-    "        mv_avg = moving_avg(all_dur, 10) \n",
+    "        mv_avg = moving_avg(all_dur, 50) \n",
     "\n",
     "        percentile = np.percentile(baseline_dur, 95)\n",
     "\n",

--- a/monitoring/RallyReports.ipynb
+++ b/monitoring/RallyReports.ipynb
@@ -124,7 +124,7 @@
     "                                         if len(d[\"error\"]) > 0])\n",
     "\n",
     "            # All Durations\n",
-    "            all_dur = success_dur + failure_dur\n",
+    "            all_dur = [d[\"duration\"] for d in all_samples]\n",
     "            # All Timestamps Sorted ASC\n",
     "            all_ts = sorted(success_timestamps + failure_timestamps)\n",
     "\n",
@@ -289,21 +289,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The data array containing the operations duration
was not in the correct order, this was causing some
charts with many failures to display an odd moving AVG
line with drastic drops or peaks